### PR TITLE
Add bluelight filter control. Bug fixes

### DIFF
--- a/app/src/main/java/uk/co/richyhbm/monochromatic/Activities/MainActivity.kt
+++ b/app/src/main/java/uk/co/richyhbm/monochromatic/Activities/MainActivity.kt
@@ -23,7 +23,7 @@ class MainActivity : AppCompatActivity() {
     private val preferencesChangeListener = SharedPreferences.OnSharedPreferenceChangeListener { _, _ ->
         if (settings.isEnabled()) {
             MonochromeService.startService(this)
-            SecureSettings.toggleMonochrome(settings.isAllowed(), contentResolver)
+            SecureSettings.toggleFilters(settings.isAllowed(), contentResolver, settings)
         } else {
             MonochromeService.stopService(this)
         }
@@ -42,7 +42,7 @@ class MainActivity : AppCompatActivity() {
         } else {
             if (settings.isEnabled()) {
                 MonochromeService.startService(this)
-                SecureSettings.toggleMonochrome(settings.isAllowed(), contentResolver)
+                SecureSettings.toggleFilters(settings.isAllowed(), contentResolver, settings)
             } else {
                 MonochromeService.stopService(this)
             }
@@ -57,7 +57,7 @@ class MainActivity : AppCompatActivity() {
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean = when (item.itemId) {
         R.id.main_menu_force_color -> {
-            SecureSettings.resetMonochrome(contentResolver)
+            SecureSettings.resetAllFilters(contentResolver, settings)
             settings.setEnabled(false)
             MonochromeService.stopService(this)
             findViewById<SwitchCompat>(R.id.enabled_switch)?.isChecked = false

--- a/app/src/main/java/uk/co/richyhbm/monochromatic/Fragments/MainFragment.kt
+++ b/app/src/main/java/uk/co/richyhbm/monochromatic/Fragments/MainFragment.kt
@@ -1,6 +1,7 @@
 package uk.co.richyhbm.monochromatic.Fragments
 
 import android.app.AlertDialog
+import android.os.Build
 import android.os.Bundle
 import android.view.*
 import kotlinx.android.synthetic.main.main_fragment.*
@@ -35,14 +36,15 @@ class MainFragment : BaseFragment() {
 
             if (settings.isEnabled()) {
                 MonochromeService.startService(requireContext())
-                if(!settings.seenNotificationDialog()) {
-                    AlertDialog.Builder(requireContext())
-                        .setMessage(getString(R.string.notification_dismiss_notice))
-                        .setPositiveButton(android.R.string.ok) { _, _ ->
-                            settings.setSeenNotificationDialog()
-                        }
-                        .create()
-                        .show()
+                if(!settings.seenNotificationDialog() &&
+                    Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                        AlertDialog.Builder(requireContext())
+                            .setMessage(getString(R.string.notification_dismiss_notice))
+                            .setPositiveButton(android.R.string.ok) { _, _ ->
+                                settings.setSeenNotificationDialog()
+                            }
+                            .create()
+                            .show()
                 }
             }
             else MonochromeService.stopService(requireContext())

--- a/app/src/main/java/uk/co/richyhbm/monochromatic/Receivers/BatteryReceiver.kt
+++ b/app/src/main/java/uk/co/richyhbm/monochromatic/Receivers/BatteryReceiver.kt
@@ -29,9 +29,9 @@ class BatteryReceiver : BroadcastReceiver() {
             val level = intent.getIntExtra(BatteryManager.EXTRA_LEVEL, 0)
 
             if(level <= settings.getLowBatteryLevel()) {
-                SecureSettings.toggleMonochrome(true, context.contentResolver)
+                SecureSettings.toggleFilters(true, context.contentResolver, settings)
             } else {
-                SecureSettings.toggleMonochrome(settings.isAllowed(), context.contentResolver)
+                SecureSettings.toggleFilters(settings.isAllowed(), context.contentResolver, settings)
             }
         }
     }

--- a/app/src/main/java/uk/co/richyhbm/monochromatic/Receivers/DisableMonochromeReceiver.kt
+++ b/app/src/main/java/uk/co/richyhbm/monochromatic/Receivers/DisableMonochromeReceiver.kt
@@ -11,7 +11,7 @@ class DisableMonochromeReceiver: BroadcastReceiver() {
         if(context != null) {
             val settings = Settings(context)
             if(settings.isEnabled() && SecureSettings.isMonochromeEnabled(context.contentResolver)) {
-                SecureSettings.resetMonochrome(context.contentResolver)
+                SecureSettings.resetAllFilters(context.contentResolver, settings)
             }
         }
     }

--- a/app/src/main/java/uk/co/richyhbm/monochromatic/Receivers/ScreenChangeReceiver.kt
+++ b/app/src/main/java/uk/co/richyhbm/monochromatic/Receivers/ScreenChangeReceiver.kt
@@ -33,7 +33,7 @@ class ScreenChangeReceiver : BroadcastReceiver() {
         val settings = Settings(context)
 
         if(settings.isEnabled()) {
-            SecureSettings.toggleMonochrome(settings.isAllowed(), context.contentResolver)
+            SecureSettings.toggleFilters(settings.isAllowed(), context.contentResolver, settings)
         }
     }
 
@@ -43,10 +43,10 @@ class ScreenChangeReceiver : BroadcastReceiver() {
         if(settings.isEnabled()) {
             if(settings.shouldDisableOnScreenOff()) {
                 if(SecureSettings.isMonochromeEnabled(context.contentResolver)) {
-                    SecureSettings.resetMonochrome(context.contentResolver)
+                    SecureSettings.resetAllFilters(context.contentResolver, settings)
                 }
             } else {
-                SecureSettings.toggleMonochrome(settings.isAllowed(), context.contentResolver)
+                SecureSettings.toggleFilters(settings.isAllowed(), context.contentResolver, settings)
             }
         }
     }

--- a/app/src/main/java/uk/co/richyhbm/monochromatic/Utilities/Constants.kt
+++ b/app/src/main/java/uk/co/richyhbm/monochromatic/Utilities/Constants.kt
@@ -1,9 +1,21 @@
 package uk.co.richyhbm.monochromatic.Utilities
 
 object Constants {
-    const val displayDaltonizerEnabled = "accessibility_display_daltonizer_enabled"
-    const val displayDaltonizer = "accessibility_display_daltonizer"
+    /** Daltonizer */
+    const val secureSetting_displayDaltonizerEnabled = "accessibility_display_daltonizer_enabled"
+    const val secureSetting_displayDaltonizer = "accessibility_display_daltonizer"
 
-    const val daltonizerDisabled = -1
-    const val daltonizerSimulateMonochrome = 0
+    const val secureSettingValue_daltonizerDisabled = -1
+    const val secureSettingValue_daltonizerSimulateMonochrome = 0
+
+    /**
+     * Night display (bluelight filter)
+     * AOSP reference:
+     * Oreo - http://androidxref.com/8.0.0_r4/xref/frameworks/base/core/java/com/android/internal/app/NightDisplayController.java
+     * Pie - http://androidxref.com/9.0.0_r3/xref/frameworks/base/core/java/com/android/internal/app/ColorDisplayController.java
+     */
+    const val secureSetting_displayBluelightFilterEnabled = "night_display_activated"
+    const val secureSetting_displayBluelightFilterTemperature = "night_display_color_temperature"
+
+    const val defaultBluelightFilterTemperature = 1600
 }

--- a/app/src/main/java/uk/co/richyhbm/monochromatic/Utilities/SecureSettings.kt
+++ b/app/src/main/java/uk/co/richyhbm/monochromatic/Utilities/SecureSettings.kt
@@ -5,23 +5,76 @@ import android.provider.Settings
 
 
 object SecureSettings {
-    fun toggleMonochrome(enabled: Boolean, contentResolver: ContentResolver) {
-        Settings.Secure.putInt(contentResolver, Constants.displayDaltonizerEnabled, enabled.int)
-        if (enabled) {
-            Settings.Secure.putInt(contentResolver, Constants.displayDaltonizer, Constants.daltonizerSimulateMonochrome)
+    fun toggleFilters(
+        enabled: Boolean,
+        contentResolver: ContentResolver,
+        settings: uk.co.richyhbm.monochromatic.Utilities.Settings
+    ) {
+        if (settings.isFilterBluelightEnabled()) {
+            toggleMonochromeAndBluelightFilter(enabled, contentResolver)
         } else {
-            Settings.Secure.putInt(contentResolver, Constants.displayDaltonizer, Constants.daltonizerDisabled)
+            toggleMonochrome(enabled, contentResolver)
+        }
+    }
+
+    fun toggleMonochrome(enabled: Boolean, contentResolver: ContentResolver) {
+        Settings.Secure.putInt(contentResolver, Constants.secureSetting_displayDaltonizerEnabled, enabled.int)
+        if (enabled) {
+            Settings.Secure.putInt(contentResolver, Constants.secureSetting_displayDaltonizer, Constants.secureSettingValue_daltonizerSimulateMonochrome)
+        } else {
+            Settings.Secure.putInt(contentResolver, Constants.secureSetting_displayDaltonizer, Constants.secureSettingValue_daltonizerDisabled)
+        }
+    }
+
+    fun resetAllFilters(contentResolver: ContentResolver, settings: uk.co.richyhbm.monochromatic.Utilities.Settings) {
+        if (settings.isFilterBluelightEnabled()) {
+            resetMonochromeAndBluelightFilter(contentResolver)
+        } else {
+            resetMonochrome(contentResolver)
         }
     }
 
     fun resetMonochrome(contentResolver: ContentResolver) {
-        Settings.Secure.putInt(contentResolver, Constants.displayDaltonizerEnabled, false.int)
-        Settings.Secure.putInt(contentResolver, Constants.displayDaltonizer, Constants.daltonizerDisabled)
+        Settings.Secure.putInt(contentResolver, Constants.secureSetting_displayDaltonizerEnabled, false.int)
+        Settings.Secure.putInt(contentResolver, Constants.secureSetting_displayDaltonizer, Constants.secureSettingValue_daltonizerDisabled)
     }
 
-    fun isMonochromeEnabled(contentResolver: ContentResolver) : Boolean {
-        return Settings.Secure.getInt(contentResolver, Constants.displayDaltonizerEnabled, false.int) == true.int &&
-            Settings.Secure.getInt(contentResolver, Constants.displayDaltonizer, Constants.daltonizerDisabled) == Constants.daltonizerSimulateMonochrome
+    fun isMonochromeEnabled(contentResolver: ContentResolver): Boolean {
+        return Settings.Secure.getInt(contentResolver, Constants.secureSetting_displayDaltonizerEnabled, false.int) == true.int &&
+                Settings.Secure.getInt(
+                    contentResolver,
+                    Constants.secureSetting_displayDaltonizer,
+                    Constants.secureSettingValue_daltonizerDisabled
+                ) == Constants.secureSettingValue_daltonizerSimulateMonochrome
+    }
+
+    fun toggleBluelightFilter(enabled: Boolean, contentResolver: ContentResolver) {
+        Settings.Secure.putInt(contentResolver, Constants.secureSetting_displayBluelightFilterEnabled, enabled.int)
+    }
+
+    fun isBluelightFilterEnabled(contentResolver: ContentResolver) =
+        Settings.Secure.getInt(contentResolver, Constants.secureSetting_displayBluelightFilterEnabled, false.int) == true.int
+
+    fun setBlueFilterTemperature(temperature: Int, contentResolver: ContentResolver) {
+        Settings.Secure.putInt(contentResolver, Constants.secureSetting_displayBluelightFilterTemperature, temperature)
+    }
+
+    fun resetBlueFilterTemperature(contentResolver: ContentResolver) {
+        Settings.Secure.putInt(contentResolver, Constants.secureSetting_displayBluelightFilterTemperature, Constants.defaultBluelightFilterTemperature)
+    }
+
+    fun toggleMonochromeAndBluelightFilter(enabled: Boolean, contentResolver: ContentResolver) {
+        toggleMonochrome(enabled, contentResolver)
+        toggleBluelightFilter(true, contentResolver)
+    }
+
+    fun isMonochromeAndBluelightFilterEnabled(contentResolver: ContentResolver): Boolean {
+        return isBluelightFilterEnabled(contentResolver) && isMonochromeEnabled(contentResolver)
+    }
+
+    fun resetMonochromeAndBluelightFilter(contentResolver: ContentResolver) {
+        resetMonochrome(contentResolver)
+        toggleBluelightFilter(false, contentResolver)
     }
 
     val Boolean.int get() = if (this) 1 else 0

--- a/app/src/main/java/uk/co/richyhbm/monochromatic/Utilities/Settings.kt
+++ b/app/src/main/java/uk/co/richyhbm/monochromatic/Utilities/Settings.kt
@@ -51,6 +51,8 @@ class Settings(val context: Context) {
 
     private fun isAlwaysOn() = getBoolean(R.string.settings_key_always_on, false)
 
+    fun isFilterBluelightEnabled() = getBoolean(R.string.settings_key_bluelight_filter_enabled, false)
+
     fun shouldDisableOnScreenOff() = getBoolean(R.string.settings_key_disable_with_screen_off, false)
 
     fun shouldEnableAtTime() = getBoolean(R.string.settings_key_enable_with_time, false)
@@ -98,6 +100,12 @@ class Settings(val context: Context) {
     }
 
     private fun isBatteryAllowed(): Boolean = shouldEnableAtLowBattery() && (getBatteryLevel() <= getLowBatteryLevel())
+
+    fun setBluelightFilterTemperature(amount: Int) {
+        setInt(R.string.settings_key_bluelight_filter_temperature, amount)
+    }
+
+    fun getBluelightFilterTemperature(): Int = getIntValue(R.string.settings_key_bluelight_filter_temperature, Constants.defaultBluelightFilterTemperature)
 
     fun isAllowed(): Boolean {
         val allowed = isAlwaysOn() || isTimeAllowed() || isBatteryAllowed()

--- a/app/src/main/res/values/settings.xml
+++ b/app/src/main/res/values/settings.xml
@@ -11,4 +11,6 @@
     <string name="settings_key_disable_screen" translatable="false">pref_key_disable_screen</string>
     <string name="settings_key_disable_session" translatable="false">pref_key_disable_session</string>
     <string name="settings_key_show_notification_dialog" translatable="false">pref_key_show_notification_dialog</string>
+    <string name="settings_key_bluelight_filter_enabled" translatable="false">pref_key_bluelight_filter_enabled</string>
+    <string name="settings_key_bluelight_filter_temperature" translatable="false">pref_key_bluelight_filter_temperature</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -11,7 +11,7 @@
     <string name="service_enabled">Monochromatic enabled</string>
     <string name="service_disabled">Monochromatic disabled</string>
     <string name="by_richyhbm">By RichyHBM</string>
-    <string name="toggle">Toggle</string>
+    <string name="toggle">Monochrome</string>
 
     <string name="disable_for_screen">Disable for screen</string>
     <string name="disable_for_session">Disable for session</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -8,6 +8,16 @@
 
     <SwitchPreference
             android:defaultValue="false"
+            android:title="Also control bluelight filter"
+            android:key="@string/settings_key_bluelight_filter_enabled" />
+
+    <Preference
+            android:defaultValue="false"
+            android:title="Bluelight filter temperature"
+            android:key="@string/settings_key_bluelight_filter_temperature" />
+
+    <SwitchPreference
+            android:defaultValue="false"
             android:title="Disable with screen off"
             android:key="@string/settings_key_disable_with_screen_off" />
 


### PR DESCRIPTION
Fixed some bugs:
- Preference dialogs now correctly default to their current value on opening (Time picker, Number picker)
- Messages specific to Oreo and above now only show if the device is indeed running Oreo or above

Added an option to also control Android's in-built bluelight filter, along with the daltonizer. Added a dialog to set the system's bluelight filter temperature.

Changed the name of the Quick Tile from "Toggle" to "Monochrome", in keeping with the naming of Android system tiles.