### PR TITLE
Explain why an adb command is required

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,4 +12,8 @@ the use of an overlay screen, to help relax your eyes at night and disincentivis
      alt="Get it on the Play Store"
      height="90">](https://play.google.com/store/apps/details?id=uk.co.richyhbm.monochromatic)
 
-ADB command to grant required permission: adb shell pm grant uk.co.richyhbm.monochromatic android.permission.WRITE_SECURE_SETTINGS
+Monochromatic needs the *Write Secure Settings* permission, which is [normally unavailable to apps][unavailable permission]. However, you can grant this permission with the following ADB command:
+
+    adb shell pm grant uk.co.richyhbm.monochromatic android.permission.WRITE_SECURE_SETTINGS
+
+[unavailable permission]: https://stackoverflow.com/a/19538956/712526


### PR DESCRIPTION
I needed the explanation. I am unwilling to give a permission through adb unnecessarily, especially when the permission does not show up in the app settings UI.